### PR TITLE
Restructure tests

### DIFF
--- a/practice_assessments/file_storage/simulation.py
+++ b/practice_assessments/file_storage/simulation.py
@@ -13,9 +13,13 @@ import sortedcontainers
 
 def simulate_coding_framework(list_of_lists):
     """
-    Simulates a coding framework operation on a list of lists of strings.
+    Simulates a coding framework operation on a list of commands, each of which is a list of strings.
 
     Parameters:
-    list_of_lists (List[List[str]]): A list of lists containing strings.
+    commands (List[List[str]]): A list of lists, where each inner list represents a command.
+                                The first element of each inner list is the command name,
+                                and the remaining elements are the command arguments.
+    Returns:
+    List: A list containing the return values for each of the executed commands.
     """
     pass

--- a/practice_assessments/file_storage/test_simulation.py
+++ b/practice_assessments/file_storage/test_simulation.py
@@ -1,57 +1,66 @@
 import unittest
-from unittest.mock import patch
 from simulation import simulate_coding_framework
+
 
 class TestSimulateCodingFramework(unittest.TestCase):
 
-    def setUp(self):
-        self.test_data_1 = [["FILE_UPLOAD", "Cars.txt", "200kb"], 
-                              ["FILE_GET", "Cars.txt"], 
-                              ["FILE_COPY", "Cars.txt", "Cars2.txt"], 
-                              ["FILE_GET", "Cars2.txt"] ]
-        self.test_data_2 = [["FILE_UPLOAD", "Foo.txt", "100kb"], 
-                            ["FILE_UPLOAD", "Bar.csv", "200kb"], 
-                            ["FILE_UPLOAD", "Baz.pdf", "300kb"],
-                            ["FILE_SEARCH", "Ba"]]
-        self.test_data_3 = [
-            ["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "Python.txt", "150kb"], 
-            ["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "CodeSignal.txt", "150kb", 3600], 
-            ["FILE_GET_AT", "2021-07-01T13:00:01", "Python.txt"], 
-            ["FILE_COPY_AT", "2021-07-01T12:00:00", "Python.txt", "PythonCopy.txt"], 
-            ["FILE_SEARCH_AT", "2021-07-01T12:00:00", "Py"],
-            ["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "Expired.txt", "100kb", 1], 
-            ["FILE_GET_AT", "2021-07-01T12:00:02", "Expired.txt"], 
-            ["FILE_COPY_AT", "2021-07-01T12:00:00", "CodeSignal.txt", "CodeSignalCopy.txt"], 
-            ["FILE_SEARCH_AT", "2021-07-01T12:00:00", "Code"]
-        ]
-        self.test_data_4 = [
-            ["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "Initial.txt", "100kb"], 
-            ["FILE_UPLOAD_AT", "2021-07-01T12:05:00", "Update1.txt", "150kb", 3600], 
-            ["FILE_GET_AT", "2021-07-01T12:10:00", "Initial.txt"], 
-            ["FILE_COPY_AT", "2021-07-01T12:15:00", "Update1.txt", "Update1Copy.txt"], 
-            ["FILE_UPLOAD_AT", "2021-07-01T12:20:00", "Update2.txt", "200kb", 1800], 
-            ["ROLLBACK", "2021-07-01T12:10:00"], 
-            ["FILE_GET_AT", "2021-07-01T12:25:00", "Update1.txt"], 
-            ["FILE_GET_AT", "2021-07-01T12:25:00", "Initial.txt"], 
-            ["FILE_SEARCH_AT", "2021-07-01T12:25:00", "Up"],
-            ["FILE_GET_AT", "2021-07-01T12:25:00", "Update2.txt"]
-        ]
+    def assert_simulation(self, test_data):
+        """
+        :param test_data: Pairs of command, expected_output. Each command is a list of strings ["commandname", "arg1", "arg2" ...]
+        and each expected_output is the expected return value for that command
+        """
+        commands, expected_outputs = zip(*test_data)
+        expected_outputs = list(expected_outputs)
+        actual_outputs = simulate_coding_framework(commands)
+        self.assertEqual(expected_outputs, actual_outputs, f"Failed for commands: {commands}")
 
     def test_group_1(self):
-        output = simulate_coding_framework(self.test_data_1)
-        self.assertEqual(output, ["uploaded Cars.txt", "got Cars.txt", "copied Cars.txt to Cars2.txt", "got Cars2.txt"])
+        test_data = [
+            (["FILE_UPLOAD", "Cars.txt", "200kb"], None),
+            (["FILE_GET", "Cars.txt"], "200kb"),
+            (["FILE_COPY", "Cars.txt", "Cars2.txt"], None),
+            (["FILE_GET", "Cars2.txt"], "200kb")
+        ]
+        self.assert_simulation(test_data)
 
     def test_group_2(self):
-        output = simulate_coding_framework(self.test_data_2)
-        self.assertEqual(output, ["uploaded Foo.txt", "uploaded Bar.csv", "uploaded Baz.pdf", "found [Baz.pdf, Bar.csv]"])
+        test_data = [
+            (["FILE_UPLOAD", "Foo.txt", "100kb"], None),
+            (["FILE_UPLOAD", "Bar.csv", "200kb"], None),
+            (["FILE_UPLOAD", "Baz.pdf", "300kb"], None),
+            (["FILE_SEARCH", "Ba"], ["Baz.pdf", "Bar.csv"])
+        ]
+        self.assert_simulation(test_data)
 
     def test_group_3(self):
-        output = simulate_coding_framework(self.test_data_3)
-        self.assertEqual(output, ["uploaded at Python.txt", "uploaded at CodeSignal.txt", "got at Python.txt", "copied at Python.txt to PythonCopy.txt", "found at [Python.txt, PythonCopy.txt]", "uploaded at Expired.txt", "file not found", "copied at CodeSignal.txt to CodeSignalCopy.txt", "found at [CodeSignal.txt, CodeSignalCopy.txt]"])
-  
+        test_data = [
+            (["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "Python.txt", "150kb"], None),
+            (["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "CodeSignal.txt", "150kb", 3600], None),
+            (["FILE_GET_AT", "2021-07-01T13:00:01", "Python.txt"], "150kb"),
+            (["FILE_COPY_AT", "2021-07-01T12:00:00", "Python.txt", "PythonCopy.txt"], None),
+            (["FILE_SEARCH_AT", "2021-07-01T12:00:00", "Py"], ["Python.txt", "PythonCopy.txt"]),
+            (["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "Expired.txt", "100kb", 1], None),
+            (["FILE_GET_AT", "2021-07-01T12:00:02", "Expired.txt"], None),
+            (["FILE_COPY_AT", "2021-07-01T12:00:00", "CodeSignal.txt", "CodeSignalCopy.txt"], None),
+            (["FILE_SEARCH_AT", "2021-07-01T12:00:00", "Code"], ["CodeSignal.txt", "CodeSignalCopy.txt"])
+        ]
+
+        self.assert_simulation(test_data)
+
     def test_group_4(self):
-        output = simulate_coding_framework(self.test_data_4)
-        self.assertEqual(output, ["uploaded at Initial.txt", "uploaded at Update1.txt", "got at Initial.txt", "copied at Update1.txt to Update1Copy.txt", "uploaded at Update2.txt", "rollback to 2021-07-01T12:10:00", "got at Update1.txt", "got at Initial.txt", "found at [Update1.txt, Update1Copy.txt, Update2.txt]", "got at Update2.txt"])
+        test_data = [
+            (["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "Initial.txt", "100kb"], None),
+            (["FILE_UPLOAD_AT", "2021-07-01T12:05:00", "Update1.txt", "150kb", 3600], None),
+            (["FILE_GET_AT", "2021-07-01T12:10:00", "Initial.txt"], "100kb"),
+            (["FILE_COPY_AT", "2021-07-01T12:15:00", "Update1.txt", "Update1Copy.txt"], None),
+            (["FILE_UPLOAD_AT", "2021-07-01T12:20:00", "Update2.txt", "200kb", 1800], None),
+            (["ROLLBACK", "2021-07-01T12:10:00"], None),
+            (["FILE_GET_AT", "2021-07-01T12:25:00", "Update1.txt"], None),
+            (["FILE_GET_AT", "2021-07-01T12:25:00", "Initial.txt"], "100kb"),
+            (["FILE_SEARCH_AT", "2021-07-01T12:25:00", "Up"], []),
+            (["FILE_GET_AT", "2021-07-01T12:25:00", "Update2.txt"], None)
+        ]
+        self.assert_simulation(test_data)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
expected: I should be able to clone the repository and implement the practice test, with minimal work that does not imitate the work I have to do for the real GCF
actual: I had to get the tests set up, there was output like "uploaded at filename.txt" that my code was expected to return, expected output did not conform to the specification (for example, the spec says that "get" should return only the file size) and in general it was too dissimilar from the real GCF environment

I have rewritten the tests so that the test-taker can just get straight to work on their implementation! :)

I have also restructured them to be easier to read: each command is now directly paired with its expected output.