### PR TITLE
Update test_group_4 to include changing state after rollback

### DIFF
--- a/practice_assessments/file_storage/test_simulation.py
+++ b/practice_assessments/file_storage/test_simulation.py
@@ -51,7 +51,7 @@ class TestSimulateCodingFramework(unittest.TestCase):
   
     def test_group_4(self):
         output = simulate_coding_framework(self.test_data_4)
-        self.assertEqual(output, ["uploaded at Initial.txt", "uploaded at Update1.txt", "got at Initial.txt", "copied at Update1.txt to Update1Copy.txt", "uploaded at Update2.txt", "rollback to 2021-07-01T12:10:00", "got at Update1.txt", "got at Initial.txt", "found at [Update1.txt, Update1Copy.txt, Update2.txt]", "got at Update2.txt"])
+        self.assertEqual(output, ["uploaded at Initial.txt", "uploaded at Update1.txt", "got at Initial.txt", "copied at Update1.txt to Update1Copy.txt", "uploaded at Update2.txt", "rollback to 2021-07-01T12:10:00", "got at Update1.txt", "got at Initial.txt", "found at [Update1.txt, Update1Copy.txt]", "file not found"])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As mentioned by others in [Issue #8](https://github.com/PaulLockett/CodeSignal_Practice_Industry_Coding_Framework/issues/8), I believe there is a bug in the test file for Level 4.

**Order of Operations**
1. `["FILE_UPLOAD_AT", "2021-07-01T12:00:00", "Initial.txt", "100kb"]`
1. `["FILE_UPLOAD_AT", "2021-07-01T12:05:00", "Update1.txt", "150kb", 3600]`
1. `["FILE_GET_AT", "2021-07-01T12:10:00", "Initial.txt"]`
1. `["FILE_COPY_AT", "2021-07-01T12:15:00", "Update1.txt", "Update1Copy.txt"]`
1. `["FILE_UPLOAD_AT", "2021-07-01T12:20:00", "Update2.txt", "200kb", 1800]`
1. `["ROLLBACK", "2021-07-01T12:10:00"]`
1. `["FILE_GET_AT", "2021-07-01T12:25:00", "Update1.txt"]`
1. `["FILE_GET_AT", "2021-07-01T12:25:00", "Initial.txt"]`
1. `["FILE_SEARCH_AT", "2021-07-01T12:25:00", "Up"]`
1. `["FILE_GET_AT", "2021-07-01T12:25:00", "Update2.txt"]`

**Issue**
After step 6 (ROLLBACK), the file `Update2.txt` should not exist because it was uploaded at `2021-07-01T12:20:00`, which is after the rollback timestamp `2021-07-01T12:10:00`.

Since the system is rolled back to the state as of `2021-07-01T12:10:00`, any files uploaded after this timestamp should no longer exist. However, the test case appears to assume `Update2.txt` is still accessible after the rollback, which contradicts the expected behavior.